### PR TITLE
feat: save lessons finished on DB when NextButton.svelte

### DIFF
--- a/src/lib/features/users/functions/postUserLessonFinished.ts
+++ b/src/lib/features/users/functions/postUserLessonFinished.ts
@@ -1,6 +1,6 @@
 import type { CurrentUserObject } from '@onflow/fcl';
 
-export const addUserLessonFinished = async (user: CurrentUserObject, lessonSlug: string) => {
+export const addUserLessonFinishedToDB = async (user: CurrentUserObject, lessonSlug: string) => {
 	const res = await fetch('/api/add-user-lesson-finished', {
 		method: 'POST',
 		body: JSON.stringify({

--- a/src/lib/stores/user-finished-lessons/userFinishedLessonsStore.ts
+++ b/src/lib/stores/user-finished-lessons/userFinishedLessonsStore.ts
@@ -2,6 +2,6 @@ import { writable } from 'svelte/store';
 
 export const userFinishedLessons = writable<string[]>([]);
 
-export const addLessonFinishedSlug = (slug: string) => {
+export const addLessonFinishedSlugToStore = (slug: string) => {
 	userFinishedLessons.update((lessonSlugs) => [...lessonSlugs, slug]);
 };

--- a/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/check-answer/CheckAnswerButton.svelte
+++ b/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/check-answer/CheckAnswerButton.svelte
@@ -9,7 +9,7 @@
 	} from '$courses/types/course-overview.interface';
 	import type { ChapterOverviewWithLessons } from '$courses/types/chapter-overview.interface';
 	import WrongAnswer from './atoms/WrongAnswer.svelte';
-	import { addUserLessonFinished } from '$lib/features/users/functions/postUserLessonFinished';
+	import { addUserLessonFinishedToDB } from '$lib/features/users/functions/postUserLessonFinished';
 	import { user } from '$lib/stores/flow/FlowStore';
 	import type { LessonOverviewWithTabs } from '$courses/types/lesson-overview.interface';
 	import type { CurrentUserObject } from '@onflow/fcl';
@@ -77,7 +77,7 @@
 			dialogOpen = true;
 
 			if ($user.addr) {
-				addUserLessonFinished($user as CurrentUserObject, activeLesson.slug);
+				addUserLessonFinishedToDB($user as CurrentUserObject, activeLesson.slug);
 			}
 		} else {
 			popOverOpen = true;

--- a/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/check-answer/correct-answer-dialog/CorrectAnswerDialogContent.svelte
+++ b/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/check-answer/correct-answer-dialog/CorrectAnswerDialogContent.svelte
@@ -5,7 +5,7 @@
 		CourseOverviewWithSlug
 	} from '$courses/types/course-overview.interface';
 	import { page } from '$app/stores';
-	import { addLessonFinishedSlug } from '$lib/stores/user-finished-lessons/userFinishedLessonsStore';
+	import { addLessonFinishedSlugToStore } from '$lib/stores/user-finished-lessons/userFinishedLessonsStore';
 	import { getContext } from 'svelte';
 	import { userFinishedLessons } from '$lib/stores/user-finished-lessons/userFinishedLessonsStore';
 	import FinishedAllCoursesDialogContent from './FinishedAllCoursesDialogContent.svelte';
@@ -25,7 +25,7 @@
 	let lessonToAdd = activeChapter.lessons[activeLessonNumber - 1].slug;
 
 	if (!$userFinishedLessons.includes(lessonToAdd)) {
-		addLessonFinishedSlug(lessonToAdd);
+		addLessonFinishedSlugToStore(lessonToAdd);
 	}
 
 	let progress = checkUserProgress(

--- a/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/next/NextButton.svelte
+++ b/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/next/NextButton.svelte
@@ -11,12 +11,15 @@
 	import CorrectAnswerDialogContent from '../check-answer/correct-answer-dialog/CorrectAnswerDialogContent.svelte';
 	import { page } from '$app/stores';
 	import {
-		addLessonFinishedSlug,
+		addLessonFinishedSlugToStore,
 		userFinishedLessons
 	} from '$lib/stores/user-finished-lessons/userFinishedLessonsStore';
 	import { getNextLessonRoute } from '../../_functions/getNextLessonRoute';
 	import { goto } from '$app/navigation';
 	import { checkUserProgress } from '../../_functions/checkUserProgress';
+	import { user } from '$lib/stores/flow/FlowStore';
+	import { addUserLessonFinishedToDB } from '$lib/features/users/functions/postUserLessonFinished';
+	import type { CurrentUserObject } from '@onflow/fcl';
 
 	export let allCourses: CourseOverviewWithSlug[];
 	export let color: keyof typeof COURSES_COLORS;
@@ -31,7 +34,10 @@
 
 	const nextLesson = () => {
 		if (!$userFinishedLessons.includes(lessonToAdd)) {
-			addLessonFinishedSlug(lessonToAdd);
+			addLessonFinishedSlugToStore(lessonToAdd);
+		}
+		if ($user.addr) {
+			addUserLessonFinishedToDB($user as CurrentUserObject, lessonToAdd);
 		}
 		goto(getNextLessonRoute(activeChapter, activeCourse, activeChapterNumber, activeLessonNumber));
 	};


### PR DESCRIPTION
I added the function, which is in charge of inserting the `slug` of the finished lesson, to the database in the component `NextButton.svelte`

When adding this function, I realized that we had two functions with very similar names and that it could be confusing. That is why I changed the names and made them a little more descriptive