### PR TITLE
feat: scroll lesson to top when loads

### DIFF
--- a/src/routes/(app)/courses/[course]/[chapter]/[lesson]/+layout.svelte
+++ b/src/routes/(app)/courses/[course]/[chapter]/[lesson]/+layout.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div class="grid h-full grid-cols-[1fr_1fr]">
-	<div class="overflow-auto">
+	<div class="article-wrapper overflow-auto">
 		<LessonArticle lessonContent={data.lessonContent} />
 	</div>
 	<slot />

--- a/src/routes/(app)/courses/[course]/[chapter]/[lesson]/_components/lesson-article/LessonArticle.svelte
+++ b/src/routes/(app)/courses/[course]/[chapter]/[lesson]/_components/lesson-article/LessonArticle.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
+	import { afterUpdate } from 'svelte';
+
 	export let lessonContent: ConstructorOfATypedSvelteComponent;
+
+	afterUpdate(() => {
+		document.querySelector('.article-wrapper')?.scrollTo({ top: 0 });
+	});
 </script>
 
 <article class="all-prose px-6 pb-6 dark:prose-invert">


### PR DESCRIPTION
With this code we achieve that when a new lesson is loaded, either because it is selected in the sidebar or after a lesson is completed, the "article" is displayed from the beginning.

I was reading and in this case the `window.scrollTo(0, 0)` doesn't work because it doesn't have auto overflow, and the parents of the `<div>` where we have the "article" have overflow-hidden. And we don't need the whole window to scroll to the top, we only need this `<div>`. So following what I saw in [this issue](https://stackoverflow.com/questions/1174863/javascript-scrollto-method-does-nothing), I put a class name to the parent `<div>` and then select it with `document.querySelector()` and there we scroll to "top: 0"