### PR TITLE
feat: move addUserLessonFinishedToDB() to CorrectAnswerDialogContent.…

### DIFF
--- a/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/check-answer/CheckAnswerButton.svelte
+++ b/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/check-answer/CheckAnswerButton.svelte
@@ -9,10 +9,7 @@
 	} from '$courses/types/course-overview.interface';
 	import type { ChapterOverviewWithLessons } from '$courses/types/chapter-overview.interface';
 	import WrongAnswer from './atoms/WrongAnswer.svelte';
-	import { addUserLessonFinishedToDB } from '$lib/features/users/functions/postUserLessonFinished';
-	import { user } from '$lib/stores/flow/FlowStore';
 	import type { LessonOverviewWithTabs } from '$courses/types/lesson-overview.interface';
-	import type { CurrentUserObject } from '@onflow/fcl';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import type { CodeTabContent } from '../../_types/tab-content.type';
 	import CorrectAnswerDialogContent from './correct-answer-dialog/CorrectAnswerDialogContent.svelte';
@@ -75,10 +72,6 @@
 
 		if (allTabsCorrect) {
 			dialogOpen = true;
-
-			if ($user.addr) {
-				addUserLessonFinishedToDB($user as CurrentUserObject, activeLesson.slug);
-			}
 		} else {
 			popOverOpen = true;
 

--- a/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/check-answer/correct-answer-dialog/CorrectAnswerDialogContent.svelte
+++ b/src/routes/(app)/courses/[course]/[chapter]/[lesson]/[tab]/_components/check-answer/correct-answer-dialog/CorrectAnswerDialogContent.svelte
@@ -13,6 +13,9 @@
 	import FinishedLessonDialogContent from './FinishedLessonDialogContent.svelte';
 	import FinishedLastLessonDialogContent from './FinishedLastLessonDialogContent.svelte';
 	import { checkUserProgress } from '../../../_functions/checkUserProgress';
+	import { user } from '$lib/stores/flow/FlowStore';
+	import { addUserLessonFinishedToDB } from '$lib/features/users/functions/postUserLessonFinished';
+	import type { CurrentUserObject } from '@onflow/fcl';
 
 	export let allCourses: CourseOverviewWithSlug[];
 	export let activeCourse: CourseOverviewWithChapters;
@@ -26,6 +29,9 @@
 
 	if (!$userFinishedLessons.includes(lessonToAdd)) {
 		addLessonFinishedSlugToStore(lessonToAdd);
+		if ($user.addr) {
+			addUserLessonFinishedToDB($user as CurrentUserObject, lessonToAdd);
+		}
 	}
 
 	let progress = checkUserProgress(


### PR DESCRIPTION
@mateoroldos nosotros en el componente `NextButton` que creamos para las lessons de type component tenemos lo siguiente:  

![image](https://github.com/emerald-dao/cryptokitties-arcade/assets/112862961/87456be3-3db3-42a6-9dc8-7700689d7735)

Por lo que los dialogs que se muestran en caso de haber terminado todos los cursos, o haber terminado ese curso, o haber hecho la ultima lesson del curso son los correctos. El problema era que en el componente `CorrectAnswerDialogContent` no teníamos la función `addUserLessonFinishedToDB`

Esa función la tenemos en `nextLesson` dentro del componente `NextButton`, y también la teníamos en el componente `CheckAnswerButton` que se ejecutaba e insertaba el `slug` cuando todas las tabs de la lesson son correctas. 

Ya que en el componente `CheckAnswerButton` cuando todas las tabs de la lesson son correctas, la variable `dialogOpen` pasa a ser `true`, se abre `CorrectAnswerDialogContent`. Entonces saqué la función del componente `CheckAnswerButton` y la puse en `CorrectAnswerDialogContent`. Entonces en todos los casos en que una lesson es correcta y se abre el dialog, se inserta el `slug` en la DB 